### PR TITLE
Properly fix broken date test

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mocha": "^2.4.5",
     "pre-commit": "^1.1.3",
     "semistandard": "7.0.5",
+    "sinon": "^1.17.4",
     "snazzy": "^4.0.0"
   },
   "semistandard": {
@@ -57,6 +58,7 @@
     "globals": [
       "describe",
       "it",
+      "beforeEach",
       "afterEach",
       "before"
     ]

--- a/test/parse_sns.test.js
+++ b/test/parse_sns.test.js
@@ -1,4 +1,8 @@
+'use strict';
+
 require('env2')('.env');
+const sinon = require('sinon');
+
 var AwsHelper = require('aws-lambda-helper');
 AwsHelper.init({
   invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789:function:mylambda:ci'
@@ -33,6 +37,13 @@ describe('parse_sns', function () {
 });
 
 describe('get_age', function () {
+  let clock;
+  beforeEach(() => {
+    clock = sinon.useFakeTimers((new Date(2016, 7, 15)).getTime());
+  });
+  afterEach(() => {
+    clock.restore();
+  });
   it('gets the age in years of a passenger given her birth date', function (done) {
     var DOB = '1986-07-14'; // Jimmy's test!
     assert(parse_sns.get_age(DOB) === 30);


### PR DESCRIPTION
Use sinon timers to mock date objects so that this test doesn't break again without warning in a year.

Fixes a "now" for the execution of this test suite to 2016-08-15 (zero indexed months ftw!).
